### PR TITLE
created the .devcontainer directory with the necessary configuration files for github codespaces

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -21,7 +21,7 @@ This Codespace is configured to use a `.env` file for environment variables.
 4.  Once the `.env` file is correctly populated, start the application by running the following command in the terminal:
 
     ```bash
-    npm start
+    node server.js
     ```
 
 5.  Codespaces will automatically detect that the application is running on port 3000 and prompt you to open it in a browser. 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,29 @@
+# Codespaces Configuration for Kinetic Constructs
+
+This directory contains the configuration for running the Kinetic Constructs project in GitHub Codespaces.
+
+## Required Secrets
+
+Before launching the codespace, or shortly after, you **must** configure the following repository or user secrets for Codespaces:
+
+1.  `ASTRA_DB_API_ENDPOINT`: Your Astra DB API endpoint URL.
+2.  `ASTRA_DB_TOKEN`: Your Astra DB Application Token (starting with `AstraCS:...`).
+
+These secrets are necessary for the application to connect to the database.
+
+Refer to the [GitHub Codespaces documentation on managing secrets](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces) for instructions on how to add them.
+
+## Getting Started
+
+Once the secrets are configured:
+
+1.  Create a new Codespace for this repository.
+2.  The environment will automatically build based on `.devcontainer/devcontainer.json`. This includes installing Node.js, Python, and project dependencies.
+3.  Once the Codespace is ready, the application dependencies will be installed via the `postCreateCommand`.
+4.  You can start the application by running the following command in the terminal:
+
+    ```bash
+    npm start
+    ```
+
+5.  Codespaces will automatically detect that the application is running on port 3000 and prompt you to open it in a browser. 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -2,25 +2,23 @@
 
 This directory contains the configuration for running the Kinetic Constructs project in GitHub Codespaces.
 
-## Required Secrets
+## Environment Setup (.env file)
 
-Before launching the codespace, or shortly after, you **must** configure the following repository or user secrets for Codespaces:
+This Codespace is configured to use a `.env` file for environment variables.
 
-1.  `ASTRA_DB_API_ENDPOINT`: Your Astra DB API endpoint URL.
-2.  `ASTRA_DB_TOKEN`: Your Astra DB Application Token (starting with `AstraCS:...`).
+1.  When the Codespace starts, if a `.env` file doesn't exist in the root directory, a copy of `.env.example` will be created as `.env`.
+2.  You **must** edit the `.env` file and replace the placeholder values with your actual Astra DB credentials:
+    *   `ASTRA_DB_API_ENDPOINT`: Your Astra DB API endpoint URL.
+    *   `ASTRA_DB_TOKEN`: Your Astra DB Application Token (starting with `AstraCS:...`).
 
-These secrets are necessary for the application to connect to the database.
-
-Refer to the [GitHub Codespaces documentation on managing secrets](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces) for instructions on how to add them.
+*Important:* The `.env` file is included in `.gitignore` and should **not** be committed to the repository.
 
 ## Getting Started
 
-Once the secrets are configured:
-
 1.  Create a new Codespace for this repository.
-2.  The environment will automatically build based on `.devcontainer/devcontainer.json`. This includes installing Node.js, Python, and project dependencies.
-3.  Once the Codespace is ready, the application dependencies will be installed via the `postCreateCommand`.
-4.  You can start the application by running the following command in the terminal:
+2.  The environment will automatically build based on `.devcontainer/devcontainer.json`, installing Node.js, Python, and project dependencies. It will also create a `.env` file from the example if needed.
+3.  **Open the `.env` file** in the root directory and fill in your `ASTRA_DB_API_ENDPOINT` and `ASTRA_DB_TOKEN`.
+4.  Once the `.env` file is correctly populated, start the application by running the following command in the terminal:
 
     ```bash
     npm start

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+{
+	"name": "Kinetic Constructs",
+	// Use a Node.js base image - choose a version compatible with your project
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye",
+
+	"features": {
+		// Add Python 3.11
+		"ghcr.io/devcontainers/features/python:1": {
+			"version": "3.11"
+		}
+	},
+
+	"forwardPorts": [3000],
+	"portsAttributes": {
+		"3000": {
+			"label": "Application",
+			"onAutoForward": "notify"
+		}
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y pipx && pipx ensurepath && pipx install uv && npm install && uv pip sync pyproject.toml",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"dbaeumer.vscode-eslint", // StandardJS/ESLint
+				"ms-python.python", // Python support
+				"ms-python.vscode-pylance", // Python IntelliSense
+				"ms-azuretools.vscode-docker", // Docker support
+                "github.codespaces"
+			]
+		}
+	},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+
+    // Ensure environment variables from Codespaces secrets are available
+    "containerEnv": {
+        "ASTRA_DB_API_ENDPOINT": "${localEnv:ASTRA_DB_API_ENDPOINT}",
+        "ASTRA_DB_TOKEN": "${localEnv:ASTRA_DB_TOKEN}"
+    }
+} 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y pipx && pipx ensurepath && pipx install uv && npm install && uv pip sync pyproject.toml && cp -n .env.example .env || true",
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y pipx && pipx ensurepath && pipx install uv && npm install && uv sync && cp -n .env.example .env || true",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,11 +19,11 @@
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// Chain commands with && to ensure failure stops execution.
-	// Install uv using the official script and source the environment.
+	// Run the entire chain within bash -c for better compatibility.
+	// Install uv using the official script. (Sourcing .cargo/env seems unnecessary here).
 	// Use npm ci for potentially more reliable installs in CI/Codespaces.
 	// Copy .env.example only if .env doesn't exist.
-	"postCreateCommand": "sudo apt-get update && curl -LsSf https://astral.sh/uv/install.sh | sh && source /home/vscode/.cargo/env && uv --version && npm ci && uv sync && ( [ -f .env ] || cp .env.example .env )",
+	"postCreateCommand": "bash -c 'sudo apt-get update -y && curl -LsSf https://astral.sh/uv/install.sh | sh && uv --version && npm ci && uv sync && ( [ -f .env ] || cp .env.example .env )'",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y pipx && pipx ensurepath && pipx install uv && npm install && uv pip sync pyproject.toml",
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y pipx && pipx ensurepath && pipx install uv && npm install && uv pip sync pyproject.toml && cp -n .env.example .env || true",
 
 	// Configure tool-specific properties.
 	"customizations": {
@@ -38,10 +38,4 @@
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
-
-    // Ensure environment variables from Codespaces secrets are available
-    "containerEnv": {
-        "ASTRA_DB_API_ENDPOINT": "${localEnv:ASTRA_DB_API_ENDPOINT}",
-        "ASTRA_DB_TOKEN": "${localEnv:ASTRA_DB_TOKEN}"
-    }
 } 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,11 @@
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y pipx && pipx ensurepath && pipx install uv && npm install && uv sync && cp -n .env.example .env || true",
+	// Chain commands with && to ensure failure stops execution.
+	// Install uv using the official script.
+	// Use npm ci for potentially more reliable installs in CI/Codespaces.
+	// Copy .env.example only if .env doesn't exist.
+	"postCreateCommand": "sudo apt-get update && curl -LsSf https://astral.sh/uv/install.sh | sh && /home/vscode/.cargo/bin/uv --version && npm ci && /home/vscode/.cargo/bin/uv sync && ( [ -f .env ] || cp .env.example .env )",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,10 +20,10 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// Chain commands with && to ensure failure stops execution.
-	// Install uv using the official script.
+	// Install uv using the official script and source the environment.
 	// Use npm ci for potentially more reliable installs in CI/Codespaces.
 	// Copy .env.example only if .env doesn't exist.
-	"postCreateCommand": "sudo apt-get update && curl -LsSf https://astral.sh/uv/install.sh | sh && /home/vscode/.cargo/bin/uv --version && npm ci && /home/vscode/.cargo/bin/uv sync && ( [ -f .env ] || cp .env.example .env )",
+	"postCreateCommand": "sudo apt-get update && curl -LsSf https://astral.sh/uv/install.sh | sh && source /home/vscode/.cargo/env && uv --version && npm ci && uv sync && ( [ -f .env ] || cp .env.example .env )",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Astra DB Credentials - Required
+# Get these from your Astra DB database dashboard
+
+ASTRA_DB_API_ENDPOINT='YOUR_ASTRA_DB_API_ENDPOINT'
+ASTRA_DB_TOKEN='YOUR_ASTRA_DB_APPLICATION_TOKEN'
+
+# Optional: Specify collection names if different from defaults
+# ASTRA_DB_COLLECTION='products' # Default used if commented out
+# ASTRA_DB_PRODUCT_COLLECTION='products' # Default used if commented out
+# ASTRA_DB_DOCUMENT_COLLECTION='documents' # Default used if commented out 


### PR DESCRIPTION
I’ve added GitHub Codespaces support to my fork of your repository: https://github.com/difli/KineticConstructs.
This includes a .env.example file and a .devcontainer folder with everything needed to automatically create a container and configure Node and Python. A copy of .env.example to .env is also handled automatically. Note that the creation of the dev container may take a few minutes.
The environment variables are pulled from the .env file, as described in your README. We could also explore leveraging GitHub credentials for this—let’s chat about it in our next catch-up.
I recommend enabling the Template Repository setting on your repo. It makes it easier for users to create their own copy.